### PR TITLE
Fix bug when instance was provisioned but has no private IP yet

### DIFF
--- a/backend/ec2.go
+++ b/backend/ec2.go
@@ -525,7 +525,7 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 
 			if lastErr != nil {
 				//Unlikely, but can happen when API request limits are reached, for example.
-				logger.WithError(err).Warn("Could not describe instance. Will retry")
+				logger.WithError(lastErr).Warn("Could not describe instance. Will retry")
 			} else {
 				if instances != nil &&
 					len(instances.Reservations) > 0 &&


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
In some occasions, AWS can take a bit longer to provision network after the instance has already been provision. That will trigger a NPE with the following stacktrace:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1e138c3]

goroutine 21752 [running]:
github.com/travis-ci/worker/backend.(*ec2Provider).Start.func1(0x2da3de0, 0xc0017d43c0, 0xc001a89eb0, 0xc000846e60, 0xc00172f1c0, 0xc0003100f0, 0xc001cdf440)
	/home/travis/gopath/src/github.com/travis-ci/worker/backend/ec2.go:531 +0xf3
created by github.com/travis-ci/worker/backend.(*ec2Provider).Start
	/home/travis/gopath/src/github.com/travis-ci/worker/backend/ec2.go:515 +0x20ba
```

Also added some error handling when doing a `DescribeInstances` - should only happen in very rare cases tho.